### PR TITLE
Explicit post sorting

### DIFF
--- a/src/static/io.clj
+++ b/src/static/io.clj
@@ -33,13 +33,14 @@
 (defn list-files [d]
   (let [d (File. (dir d))] 
     (if (.isDirectory d)
-      (filter
-       #(let [[metadata _] (read-markdown %)
-	      published? (:published metadata)]
-	  (if (or (nil? published?)
-		  (= published? "true"))
-	    true false))
-       (FileUtils/listFiles d (into-array ["markdown"]) true)) [] )))
+      (sort
+       (filter
+        #(let [[metadata _] (read-markdown %)
+               published? (:published metadata)]
+           (if (or (nil? published?)
+                   (= published? "true"))
+             true false))
+        (FileUtils/listFiles d (into-array ["markdown"]) true))) [])))
 
 (def read-template
      (memoize


### PR DESCRIPTION
Hi nakkaya,

somehow my posts weren't sorted in the right order so I added an explicit sort in the list-files function.
I am using Ubuntu so this could be some kind of filesystem or even JVM implementation issue.

Best regards,
Norrit
