### PR TITLE
Update Markdown processor to PegDownProcessor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,11 @@
                  [org.clojure/tools.cli "0.2.1"]
                  [org.clojure/tools.logging "0.2.3"]
                  [hiccup "0.3.8"]
-                 [org.markdownj/markdownj "0.3.0-1.0.2b4"]
+                 [org.pegdown/pegdown "1.1.0"]
                  [org.clojars.amit/commons-io "1.4.0"]
                  [ring/ring-core "1.0.2"]
                  [ring/ring-jetty-adapter "1.0.2"]]
+  
   :main static.core
   :jar-name "static.jar"
   :uberjar-name "static-app.jar")

--- a/src/static/io.clj
+++ b/src/static/io.clj
@@ -3,11 +3,12 @@
         [clojure.java.shell :only [sh]]
         [hiccup core])
   (:use static.config :reload-all)
-  (:import (com.petebevin.markdown MarkdownProcessor)
+  (:import (org.pegdown PegDownProcessor)
            (java.io File)
            (org.apache.commons.io FileUtils FilenameUtils)))
 
-(defn- markdown [txt] (.markdown (MarkdownProcessor.) txt))
+(def markdown-processor (PegDownProcessor.))
+(defn- markdown [txt] (.markdownToHtml markdown-processor txt))
 
 (defn- split-file [content]
   (let [idx (.indexOf content "---" 4)]


### PR DESCRIPTION
[org.pegdown.PegDownProcessor](https://github.com/sirthias/pegdown) is a more recently maintained Markdown library and has options to handle more of the extended Markdown syntax people have grown to love, such as fenced code blocks.
