### PR TITLE
Add the ability to generate CSS files using cssgen

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojure/tools.cli "0.2.1"]
                  [org.clojure/tools.logging "0.2.3"]
+                 [cssgen "0.3.0-SNAPSHOT"]
 		 [hiccup "0.3.8"]
 		 [org.markdownj/markdownj "0.3.0-1.0.2b4"]
 		 [org.clojars.amit/commons-io "1.4.0"]

--- a/readme.org
+++ b/readme.org
@@ -103,6 +103,7 @@ Supported markup languages,
  - markdown
  - org-mode (via emacs)
  - clojure (hiccup)
+ - cssgen
  - html
 
 *** Setting per page/post settings
@@ -131,6 +132,10 @@ header placed at the top of the file,
 #+BEGIN_SRC clojure
   {:title "Blogging Like a Hacker"}
 #+END_SRC
+
+**** cssgen
+
+cssgen does not support file-specific settings.
 
 *** Page/Post Settings
 

--- a/src/static/config.clj
+++ b/src/static/config.clj
@@ -9,6 +9,7 @@
                 :in-dir "resources/"
                 :out-dir "html/"
                 :default-template "default.clj"
+                :default-extension "html"
                 :encoding "UTF-8"
                 :posts-per-page 2
                 :blog-as-index true}]

--- a/src/static/io.clj
+++ b/src/static/io.clj
@@ -1,7 +1,8 @@
 (ns static.io
   (:use [clojure.tools logging]
         [clojure.java.shell :only [sh]]
-        [hiccup core])
+        [hiccup core]
+        [cssgen])
   (:use static.config :reload-all)
   (:import (com.petebevin.markdown MarkdownProcessor)
            (java.io File)
@@ -48,6 +49,12 @@
                               (str \( (slurp file :encoding (:encoding (config))) \)))]
     [metadata (binding [*ns* (the-ns 'static.core)] (-> content eval html))]))
 
+(defn- read-cssgen [file]
+  (let [metadata {:extension "css" :template :none}
+        content (read-string
+                 (slurp file :encoding (:encoding (config))))]
+    [metadata (binding [*ns* (the-ns 'static.core)] (-> content eval css))]))  
+
 (def read-doc
      (memoize
       (fn [f]
@@ -58,6 +65,7 @@
                 (= extension "org") (read-org f)
                 (= extension "html") (read-html f)
                 (= extension "clj") (read-clj f)
+                (= extension "cssgen") (read-cssgen f)
                 :default (throw (Exception. "Unknown Extension.")))))))
 
 (defn dir-path [dir]
@@ -80,6 +88,7 @@
         (FileUtils/listFiles d (into-array ["markdown"
                                             "md"
                                             "clj"
+                                            "cssgen"
                                             "org"
                                             "html"]) true))) [] )))
 

--- a/test/static/test/core.clj
+++ b/test/static/test/core.clj
@@ -27,6 +27,10 @@
     (is (= "Some dummy file for unit testing."
 	   (re-find #"Some dummy file for unit testing." content)))))
 
+(deftest test-cssgen
+  (let [[metadata content] (read-doc "resources/site/style.cssgen")]
+    (is (= "font-size: 1em;" (re-find #"font-size: 1em;" content)))))
+
 (deftest test-org
   (let [[metadata content] (read-doc (File. "resources/posts/2050-07-07-dummy-future-post-7.org"))] 
     (is (= "org-mode org-babel"  (:tags metadata)))

--- a/test/static/test/dummy_fs.clj
+++ b/test/static/test/dummy_fs.clj
@@ -17,6 +17,9 @@ tags: unit test
 ---
 
 Some dummy file for unit testing.")
+
+  (spit (File. "resources/site/style.cssgen")
+  "[:body :font-size :1em]")      
   
 (spit (File. "resources/site/dummy_clj.clj")
 	"{:title \"Dummy Clj File\"}


### PR DESCRIPTION
- Added global setting for :default-extension that sets the default
  generated file extension
- Added file-specific setting for :extension
- Added :none option for :template that prevents the file from using
  a template
