### PR TITLE
Fixed RejectedExecutionException when watching files

### DIFF
--- a/src/static/core.clj
+++ b/src/static/core.clj
@@ -419,6 +419,7 @@
       (when (and (:atomic-build (config))
                  build)
         (FileUtils/deleteDirectory (File. out-dir))
-        (FileUtils/moveDirectory (File. tmp-dir) (File. out-dir)))))
+        (FileUtils/moveDirectory (File. tmp-dir) (File. out-dir))))
   
-  (shutdown-agents))
+    (when-not watch
+      (shutdown-agents))))


### PR DESCRIPTION
Hi Nakkaya!

Thanks for writing this project. It so simple yet so useful :+1: 

I had a problem when using the `--watch` option:

```
java -jar static-app.jar --watch
2013-10-05 20:16:10.369:INFO::Logging to STDERR via org.mortbay.log.StdErrLog
2013-10-05 20:16:10.386:INFO::jetty-6.1.x
2013-10-05 20:16:10.953:INFO::Started SocketConnector@0.0.0.0:8080
[+] INFO: Rebuilding site...
[+] INFO: Processing Public  0.0010 secs
[+] WARNING: Exception thrown while building site! java.util.concurrent.RejectedExecutionException
```

This `RejectedExecutionException` caused the the out-dir to not be generated. This problem only happened with `--watch`. The `--build` option worked fine and generated the build correctly.

I tracked down this problem to the `(shutdown-agents)` call. It seems that it was killing the watcher threads.

Canassa,
