### PR TITLE
Fix potentially invalid pager link

### DIFF
--- a/src/static/core.clj
+++ b/src/static/core.clj
@@ -192,7 +192,7 @@
                [:a {:href (str "/latest-posts/" (+ page 1) "/")} 
                 "Newer Entries &raquo;"]]]
     (cond
-     (< count-total posts-per-page) nil
+     (<= count-total posts-per-page) nil
      (= page max-index) (list older)
      (= page 0) (list newer)
      :default (list older newer))))


### PR DESCRIPTION
If a blog has exactly :posts-per-page posts (2 in the default configuration), the pager will still create an "Older Entries" link to latest-posts/-1/.  

This patch just changes the pager condition from (< count-total posts-per-page) to (<= count-total posts-per-page) in order to prevent this from happening.
