### PR TITLE
'site-url' to handle Windows backslashes in file name

### DIFF
--- a/src/static/core.clj
+++ b/src/static/core.clj
@@ -51,6 +51,7 @@
 
 (defn site-url [f & [ext]]
   (-> (str f)
+      (.replaceAll "\\\\" "/")
       (.replaceAll (dir-path :site) "")
       (FilenameUtils/removeExtension)
       (str "."


### PR DESCRIPTION
Very small fix to make static work on Windows. It deals with the Windows file names using backslashes (\) in site-url in core.clj. Hopefully useful for someone like me using a Windows machine. :)
